### PR TITLE
Update maven orb version in examples

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -132,7 +132,7 @@ workflows:
       - orb-tools/publish:
           orb_name: ft-circleci-orbs/cloudsmith-maven
           vcs_type: << pipeline.project.type >>
-          pub_type: dev
+          pub_type: production
           # Ensure this job requires all test jobs and the pack job.
           requires:
             - orb-tools/pack

--- a/src/examples/configure_maven_and_install_dependencies.yml
+++ b/src/examples/configure_maven_and_install_dependencies.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.0
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.2
   jobs:
     build:
       docker:

--- a/src/examples/configure_maven_and_install_dependencies.yml
+++ b/src/examples/configure_maven_and_install_dependencies.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.1
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.0
   jobs:
     build:
       docker:

--- a/src/examples/set_env_vars_for_maven.yml
+++ b/src/examples/set_env_vars_for_maven.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.0
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.2
   jobs:
     build:
       docker:

--- a/src/examples/set_env_vars_for_maven.yml
+++ b/src/examples/set_env_vars_for_maven.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.1
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.0
   jobs:
     build:
       docker:

--- a/src/examples/upload_package_native.yml
+++ b/src/examples/upload_package_native.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.0
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.2
   jobs:
     build:
       docker:

--- a/src/examples/upload_package_native.yml
+++ b/src/examples/upload_package_native.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.1
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.0
   jobs:
     build:
       docker:

--- a/src/examples/upload_package_using_cli.yml
+++ b/src/examples/upload_package_using_cli.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.0
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.2
   jobs:
     build:
       docker:

--- a/src/examples/upload_package_using_cli.yml
+++ b/src/examples/upload_package_using_cli.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.1
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.0
   jobs:
     build:
       docker:


### PR DESCRIPTION
## Why?

- We want to update the version of the Orb and publish to production so that early access of the Maven Orb is available via the Circleci Orb site.

## What?

- Update version of Orb to v.0.0.2
- Switch Orb type to production