### PR TITLE
Update orb version in orb doc examples

### DIFF
--- a/.circleci/simple-maven-package-test/maven-package-test/pom.xml
+++ b/.circleci/simple-maven-package-test/maven-package-test/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.mycompany.app</groupId>
   <artifactId>maven-package-test</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.4</version>
+  <version>1.0.3</version>
   <name>maven-package-test</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/.circleci/simple-maven-package-test/maven-package-test/pom.xml
+++ b/.circleci/simple-maven-package-test/maven-package-test/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.mycompany.app</groupId>
   <artifactId>maven-package-test</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <name>maven-package-test</name>
   <url>http://maven.apache.org</url>
   <dependencies>

--- a/src/examples/configure_maven_and_install_dependencies.yml
+++ b/src/examples/configure_maven_and_install_dependencies.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.2
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.2
   jobs:
     build:
       docker:

--- a/src/examples/set_env_vars_for_maven.yml
+++ b/src/examples/set_env_vars_for_maven.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.2
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.2
   jobs:
     build:
       docker:

--- a/src/examples/upload_package_native.yml
+++ b/src/examples/upload_package_native.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.2
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.2
   jobs:
     build:
       docker:

--- a/src/examples/upload_package_using_cli.yml
+++ b/src/examples/upload_package_using_cli.yml
@@ -3,7 +3,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@0.0.2
+    cloudsmith-maven: ft-circleci-orbs/cloudsmith-maven@1.0.2
   jobs:
     build:
       docker:


### PR DESCRIPTION
## Why?

- Conflicting Orb versions is confusing for our customers

## What?

- Update Orb version to 1.0.2 in examples, factoring in patch incrementation
